### PR TITLE
somehow config is not working, base_path used instead

### DIFF
--- a/src/ModuleServiceProvider.php
+++ b/src/ModuleServiceProvider.php
@@ -16,7 +16,7 @@ class ModuleServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(__DIR__ . '/config.php', 'laragine');
 
         module_autoloader();
-        module_autoloader('Plugins', config('laragine.plugins_dir'));
+        module_autoloader('Plugins', base_path() . '/plugins');
 
         if (class_exists('Core\\Base\\ModuleServiceProvider')) {
             /**

--- a/src/Traits/Exceptions/Handler.php
+++ b/src/Traits/Exceptions/Handler.php
@@ -10,7 +10,7 @@ use Core\Base\Traits\Response\SendResponse;
 
 if (!class_exists(SendResponse::class, false)) {
     module_autoloader();
-    module_autoloader('Plugins', config('laragine.plugins_dir'));
+    module_autoloader('Plugins', base_path() . '/plugins');
 }
 
 trait Handler

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -44,7 +44,7 @@ if (!function_exists('module_autoloader')) {
      */
     function module_autoloader($namespace = 'Core', $dir = '')
     {
-        $dir = empty($dir) ? config('laragine.root_dir') : $dir;
+        $dir = empty($dir) ? base_path() . '/core' : $dir;
 
         // instantiate the loader
         $loader = new \Yepwoo\Laragine\Support\Psr4AutoloaderClass;


### PR DESCRIPTION
As mentioned in the title, using `config('laragine.root_dir')` for example is not working in some files(updated files), somehow the config is not working and thus it returns `null` ... tested in Laravel 10.x and it has been fixed by using `base_path()` instead.